### PR TITLE
Adds zoom controls

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -22,12 +22,26 @@
           "type": "Integer",
           "description": "Count of active adjustments",
           "default": 0
+        },
+        {
+          "name": "showZoomControls",
+          "type": "Boolean",
+          "description": "Toggles rendering of zoom controls",
+          "default": true
         }
       ],
       "events": [
         {
           "name": "visualAdjustmentOptionChanged",
           "description": "Fires when options have loaded or changed"
+        },
+        {
+          "name": "visualAdjustmentZoomIn",
+          "description": "Zoom in button clicked"
+        },
+        {
+          "name": "visualAdjustmentZoomOut",
+          "description": "Zoom out button clicked"
         }
       ],
       "slots": [],

--- a/demo/index.html
+++ b/demo/index.html
@@ -124,6 +124,9 @@
       active: false,
     }];
 
+    const zoomInCallback = () => console.log('zoom in clicked');
+    const zoomOutCallback = () => console.log('zoom out clicked');
+
     const adjustmentMenu = {
       icon: html`
         <ia-icon-visual-adjustment></ia-icon-visual-adjustment>
@@ -131,7 +134,14 @@
       label: 'Visual Adjustments',
       menuDetails: '(click to see the possibilities)',
       id: 'adjustment',
-      component: html`<ia-book-visual-adjustments ?renderHeader=${true} .options=${visualAdjustmentOptions}></ia-book-visual-adjustments>`
+      component: html`
+        <ia-book-visual-adjustments
+          ?renderHeader=${true}
+          .options=${visualAdjustmentOptions}
+          @visualAdjustmentZoomIn=${zoomInCallback}
+          @visualAdjustmentZoomOut=${zoomOutCallback}
+        ></ia-book-visual-adjustments>
+      `
     };
 
     menuSlider.menus = [adjustmentMenu];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1084,6 +1084,22 @@
         "lit-html": "^1.2.1"
       }
     },
+    "@internetarchive/icon-magnify-minus": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-magnify-minus/-/icon-magnify-minus-1.2.0.tgz",
+      "integrity": "sha512-KsZC8xRYcPdl/uQiLI43DdNWD2NijVhQU6MGKHwUrC2oubyAW0JQtowN/U1LsHtHNHbs8XBzeeu0vyqfBN5/mw==",
+      "requires": {
+        "lit-html": "^1.2.1"
+      }
+    },
+    "@internetarchive/icon-magnify-plus": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-magnify-plus/-/icon-magnify-plus-1.2.0.tgz",
+      "integrity": "sha512-W4t6aMQwSoEQieGTyHEWR+osDYXqS9DshUsPpCLcUPHnbUiET9AtZmCBnbFf4SpnSkREPCZpYljMQPiy9AS9MA==",
+      "requires": {
+        "lit-html": "^1.2.1"
+      }
+    },
     "@internetarchive/icon-visual-adjustment": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@internetarchive/icon-visual-adjustment/-/icon-visual-adjustment-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   },
   "dependencies": {
     "@internetarchive/icon-collapse-sidebar": "^1.1.0",
+    "@internetarchive/icon-magnify-minus": "^1.2.0",
+    "@internetarchive/icon-magnify-plus": "^1.2.0",
     "lit-element": "^2.2.1",
     "lit-html": "^1.1.2"
   },

--- a/src/ia-book-visual-adjustments.js
+++ b/src/ia-book-visual-adjustments.js
@@ -2,10 +2,17 @@ import { html, LitElement } from 'lit-element';
 import { repeat } from 'lit-html/directives/repeat.js';
 import { nothing } from 'lit-html';
 import bookVisualAdjustmentsCSS from './styles/ia-book-visual-adjustments.js';
+import '@internetarchive/icon-magnify-minus/icon-magnify-minus';
+import '@internetarchive/icon-magnify-plus/icon-magnify-plus';
+
+const namespacedEvent = eventName => `visualAdjustment${eventName}`;
 
 const events = {
-  optionChange: 'visualAdjustmentOptionChanged',
+  optionChange: namespacedEvent('OptionChanged'),
+  zoomIn: namespacedEvent('ZoomIn'),
+  zoomOut: namespacedEvent('ZoomOut'),
 };
+
 export class IABookVisualAdjustments extends LitElement {
   static get styles() {
     return bookVisualAdjustmentsCSS;
@@ -13,18 +20,20 @@ export class IABookVisualAdjustments extends LitElement {
 
   static get properties() {
     return {
-      renderHeader: { type: Boolean },
-      options: { type: Array },
       activeCount: { type: Number },
+      options: { type: Array },
+      renderHeader: { type: Boolean },
+      showZoomControls: { type: Boolean },
     };
   }
 
   constructor() {
     super();
 
-    this.renderHeader = false;
-    this.options = [];
     this.activeCount = 0;
+    this.options = [];
+    this.renderHeader = false;
+    this.showZoomControls = true;
   }
 
   firstUpdated() {
@@ -65,6 +74,14 @@ export class IABookVisualAdjustments extends LitElement {
       composed: true,
       detail,
     }));
+  }
+
+  emitZoomIn() {
+    this.dispatchEvent(new CustomEvent(events.zoomIn));
+  }
+
+  emitZoomOut() {
+    this.dispatchEvent(new CustomEvent(events.zoomOut));
   }
 
   /**
@@ -129,11 +146,24 @@ export class IABookVisualAdjustments extends LitElement {
     return this.renderHeader ? header : nothing;
   }
 
+  get zoomControls() {
+    return html`
+      <h4>Zoom</h4>
+      <button class="zoom_out" @click=${this.emitZoomOut} title="zoom out">
+        <ia-icon-magnify-minus></ia-icon-magnify-minus>
+      </button>
+      <button class="zoom_in" @click=${this.emitZoomIn} title="zoom in">
+        <ia-icon-magnify-plus></ia-icon-magnify-plus>
+      </button>
+    `;
+  }
+
   /** @inheritdoc */
   render() {
     return html`
       ${this.headerSection}
       <ul>${repeat(this.options, option => option.id, this.adjustmentCheckbox.bind(this))}</ul>
+      ${this.showZoomControls ? this.zoomControls : nothing}
     `;
   }
 }

--- a/src/styles/ia-book-visual-adjustments.js
+++ b/src/styles/ia-book-visual-adjustments.js
@@ -72,4 +72,28 @@ label {
 .range p {
   margin-left: 1rem;
 }
+
+h4 {
+  padding: 1rem 0;
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+button {
+  -webkit-appearance: none;
+  appearance: none;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  outline: none;
+  cursor: pointer;
+  --iconWidth: 40px;
+  --iconHeight: 40px;
+  --iconFillColor: var(--primaryTextColor);
+  --iconStrokeColor: var(--primaryTextColor);
+}
+
+button * {
+  display: inline-block;
+}
 `;

--- a/test/ia-book-visual-adjustments.test.js
+++ b/test/ia-book-visual-adjustments.test.js
@@ -1,4 +1,9 @@
-import { html, fixture, expect } from '@open-wc/testing';
+import {
+  html,
+  fixture,
+  expect,
+  oneEvent,
+} from '@open-wc/testing';
 import sinon from 'sinon';
 import { IABookVisualAdjustments } from '../src/ia-book-visual-adjustments.js';
 
@@ -40,7 +45,7 @@ describe('<ia-book-visual-adjustments>', () => {
     expect(el.renderHeader).to.exist;
     expect(el.renderHeader).to.be.false;
     expect(el.activeCount).to.exist;
-    expect(el.renderHeader).to.be.false;
+    expect(el.showZoomControls).to.be.true;
   });
 
   it('renders all properties of a visual adjustment option', async () => {
@@ -77,6 +82,23 @@ describe('<ia-book-visual-adjustments>', () => {
     await el.updateComplete;
 
     expect(el.options[0].active).to.equal(false);
+  });
+
+  it('renders zoom in and out controls when enabled', async () => {
+    const el = await fixture(container());
+
+    expect(el.shadowRoot.querySelector('.zoom_out')).to.exist;
+    expect(el.shadowRoot.querySelector('.zoom_in')).to.exist;
+  });
+
+  it('does not render zoom controls when disabled', async () => {
+    const el = await fixture(container());
+
+    el.showZoomControls = false;
+    await el.updateComplete;
+
+    expect(el.shadowRoot.querySelector('.zoom_out')).not.to.exist;
+    expect(el.shadowRoot.querySelector('.zoom_in')).not.to.exist;
   });
 
   describe('Custom events', () => {
@@ -125,6 +147,28 @@ describe('<ia-book-visual-adjustments>', () => {
 
       el.shadowRoot.querySelector('[name="brightness_range"]').dispatchEvent(new Event('change'));
       expect(el.emitOptionChangedEvent.callCount).to.equal(2);
+    });
+
+    it('emits a zoom out event when zoom out button clicked', async () => {
+      const el = await fixture(container());
+
+      setTimeout(() => (
+        el.shadowRoot.querySelector('.zoom_out').click()
+      ));
+      const response = await oneEvent(el, 'visualAdjustmentZoomOut');
+
+      expect(response).to.exist;
+    });
+
+    it('emits a zoom in event when zoom in button clicked', async () => {
+      const el = await fixture(container());
+
+      setTimeout(() => (
+        el.shadowRoot.querySelector('.zoom_in').click()
+      ));
+      const response = await oneEvent(el, 'visualAdjustmentZoomIn');
+
+      expect(response).to.exist;
     });
   });
 


### PR DESCRIPTION
This adds zoom in and out buttons by default to the visual adjustments submenu. Separate events are emitted on click, and are meant to be tied to functions that trigger `bookReader.zoom(1)` for zoom in and `bookReader.zoom(-1)` for zoom out.

<img width="266" alt="Screen Shot 2020-10-08 at 3 42 11 PM" src="https://user-images.githubusercontent.com/39553/95505809-fa029500-097c-11eb-8142-5ee847a11d1d.png">
